### PR TITLE
Fix compatibility with boost 1.59 and 1.60

### DIFF
--- a/Schweizer-Messer/sm_boost/include/boost/portable_binary_archive.hpp
+++ b/Schweizer-Messer/sm_boost/include/boost/portable_binary_archive.hpp
@@ -1,7 +1,7 @@
 #ifndef PORTABLE_BINARY_ARCHIVE_HPP
 #define PORTABLE_BINARY_ARCHIVE_HPP
 
-// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com .
 // Use, modification and distribution is subject to the Boost Software
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -13,7 +13,13 @@
 
 #include <boost/config.hpp>
 #include <boost/cstdint.hpp>
+
+// breaking changes in boost >=1.59
+#if BOOST_VERSION >= 105900
+#else
 #include <boost/serialization/pfto.hpp>
+#endif
+
 #include <boost/static_assert.hpp>
 
 #include <climits>
@@ -47,7 +53,6 @@ reverse_bytes(char size, char *address){
     }
 }
 
-        
     } // namespace archive
 } // namespace boost
 

--- a/Schweizer-Messer/sm_boost/include/boost/portable_binary_oarchive.hpp
+++ b/Schweizer-Messer/sm_boost/include/boost/portable_binary_oarchive.hpp
@@ -14,7 +14,7 @@
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
 // portable_binary_oarchive.hpp
 
-// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com .
 // Use, modification and distribution is subject to the Boost Software
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -32,16 +32,16 @@
 
 namespace boost {
     namespace archive {
-        
+
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
 // exception to be thrown if integer read from archive doesn't fit
 // variable being loaded
-class portable_binary_oarchive_exception : 
+class portable_binary_oarchive_exception :
     public virtual boost::archive::archive_exception
 {
 public:
     typedef enum {
-        invalid_flags 
+        invalid_flags
     } exception_code;
   portable_binary_oarchive_exception(exception_code /* c */ )
     {}
@@ -61,14 +61,14 @@ public:
 };
 
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
-// "Portable" output binary archive.  This is a variation of the native binary 
+// "Portable" output binary archive.  This is a variation of the native binary
 // archive. it addresses integer size and endienness so that binary archives can
 // be passed across systems. Note:floating point types not addressed here
 
 class portable_binary_oarchive :
     public boost::archive::basic_binary_oprimitive<
         portable_binary_oarchive,
-        std::ostream::char_type, 
+        std::ostream::char_type,
         std::ostream::traits_type
     >,
     public boost::archive::detail::common_oarchive<
@@ -77,7 +77,7 @@ class portable_binary_oarchive :
 {
     typedef boost::archive::basic_binary_oprimitive<
         portable_binary_oarchive,
-        std::ostream::char_type, 
+        std::ostream::char_type,
         std::ostream::traits_type
     > primitive_base_t;
     typedef boost::archive::detail::common_oarchive<
@@ -133,9 +133,22 @@ protected:
 
     // default processing - kick back to base class.  Note the
     // extra stuff to get it passed borland compilers
-    typedef boost::archive::detail::common_oarchive<portable_binary_oarchive> 
+    typedef boost::archive::detail::common_oarchive<portable_binary_oarchive>
         detail_common_oarchive;
     template<class T>
+// breaking changes in boost >=1.59
+#if BOOST_VERSION >= 105900
+    void save_override(T & t){
+        this->detail_common_oarchive::save_override(t);
+    }
+    // explicitly convert to char * to avoid compile ambiguities
+    void save_override(const boost::archive::class_name_type & t){
+        const std::string s(t);
+        * this << s;
+    }
+    // binary files don't include the optional information
+    void save_override(const boost::archive::class_id_optional_type & /* t */){}
+#else
     void save_override(T & t, BOOST_PFTO int){
         this->detail_common_oarchive::save_override(t, 0);
     }
@@ -144,11 +157,9 @@ protected:
         const std::string s(t);
         * this << s;
     }
-    // binary files don't include the optional information 
-    void save_override(
-        const boost::archive::class_id_optional_type & /* t */, 
-        int
-    ){}
+    // binary files don't include the optional information
+    void save_override(const boost::archive::class_id_optional_type & /* t */, int){}
+#endif
 
     void init(unsigned int flags);
 public:
@@ -165,13 +176,13 @@ public:
 
     portable_binary_oarchive(
         std::basic_streambuf<
-            std::ostream::char_type, 
+            std::ostream::char_type,
             std::ostream::traits_type
-        > & bsb, 
+        > & bsb,
         unsigned int flags
     ) :
         primitive_base_t(
-            bsb, 
+            bsb,
             0 != (flags & boost::archive::no_codecvt)
         ),
         archive_base_t(flags),

--- a/Schweizer-Messer/sm_boost/src/portable_binary_iarchive.cpp
+++ b/Schweizer-Messer/sm_boost/src/portable_binary_iarchive.cpp
@@ -1,7 +1,7 @@
 /////////1/////////2/////////3/////////4/////////5/////////6/////////7/////////8
 // portable_binary_iarchive.cpp
 
-// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com . 
+// (C) Copyright 2002 Robert Ramey - http://www.rrsd.com .
 // Use, modification and distribution is subject to the Boost Software
 // License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
@@ -19,7 +19,7 @@
 namespace boost {
 namespace archive {
 
-void 
+void
 portable_binary_iarchive::load_impl(boost::intmax_t & l, char maxsize){
     char size;
     l = 0;
@@ -50,18 +50,28 @@ portable_binary_iarchive::load_impl(boost::intmax_t & l, char maxsize){
         if(m_flags & endian_big)
     #endif
             reverse_bytes(size, cptr);
-    
+
     if(negative)
         l = -l;
 }
 
 void
 portable_binary_iarchive::load_override(
-    boost::archive::class_name_type & t, int
+    boost::archive::class_name_type & t
+// breaking changes in boost >=1.59
+#if BOOST_VERSION >= 105900
+#else
+    , int
+#endif
 ){
     std::string cn;
     cn.reserve(BOOST_SERIALIZATION_MAX_KEY_SIZE);
+// breaking changes in boost >=1.59
+#if BOOST_VERSION >= 105900
+    load_override(cn);
+#else
     load_override(cn, 0);
+#endif
     if(cn.size() > (BOOST_SERIALIZATION_MAX_KEY_SIZE - 1))
         boost::serialization::throw_exception(
             boost::archive::archive_exception(
@@ -72,7 +82,7 @@ portable_binary_iarchive::load_override(
     t.t[cn.size()] = '\0';
 }
 
-void 
+void
 portable_binary_iarchive::init(unsigned int flags){
     if(0 == (flags & boost::archive::no_header)){
         // read signature in an archive version independent manner
@@ -96,7 +106,7 @@ portable_binary_iarchive::init(unsigned int flags){
                     boost::archive::archive_exception::unsupported_version
                 )
             );
-        
+
         #if BOOST_WORKAROUND(__MWERKS__, BOOST_TESTED_AT(0x3205))
         this->set_library_version(input_library_version);
         //#else
@@ -127,7 +137,7 @@ namespace detail {
 
 template class basic_binary_iprimitive<
     portable_binary_iarchive,
-    std::istream::char_type, 
+    std::istream::char_type,
     std::istream::traits_type
 > ;
 

--- a/aslam_cv/aslam_cv_python/src/CameraProjections.cpp
+++ b/aslam_cv/aslam_cv_python/src/CameraProjections.cpp
@@ -215,6 +215,8 @@ void exportGenericDistortionFunctions(T & dist) {
 
 void exportFovDistortionFunctions() {
   class_<FovDistortion, boost::shared_ptr<FovDistortion> > distortion("FovDistortion", init<>());
+  register_ptr_to_python<boost::shared_ptr<FovDistortion> >();
+
   exportGenericDistortionFunctions<FovDistortion>(distortion);
   distortion.def(init<double>(("FovDistortion(double w)")));
   distortion.def("w", &FovDistortion::w);
@@ -225,6 +227,8 @@ void exportRadialTangentialDistortionFunctions() {
   class_<RadialTangentialDistortion,
       boost::shared_ptr<RadialTangentialDistortion> > rtDistortion(
       "RadialTangentialDistortion", init<>());
+  register_ptr_to_python<boost::shared_ptr<RadialTangentialDistortion> >();
+
   exportGenericDistortionFunctions<RadialTangentialDistortion>(rtDistortion);
 
   rtDistortion.def(
@@ -247,6 +251,8 @@ void exportOmniProjection(std::string name) {
 
   class_<OmniProjection<D>, boost::shared_ptr<OmniProjection<D> > > omniProjection(
       name.c_str(), init<>());
+  register_ptr_to_python<boost::shared_ptr<OmniProjection<D> > >();
+
   omniProjection.def(init<>((name + "(distortion_t distortion)").c_str())).def(
       init<double, double, double, double, double, int, int, D>(
           (name
@@ -289,6 +295,8 @@ void exportPinholeProjection(std::string name) {
 
   class_<PinholeProjection<D>, boost::shared_ptr<PinholeProjection<D> > > pinholeProjection(
       name.c_str(), init<>());
+  register_ptr_to_python<boost::shared_ptr<PinholeProjection<D> > >();
+
   pinholeProjection.def(init<>((name + "(distortion_t distortion)").c_str()))
       .def(
       init<double, double, double, double, int, int, D>(
@@ -331,10 +339,14 @@ void exportCameraProjections() {
 
   class_<NoDistortion, boost::shared_ptr<NoDistortion> > noDistortion(
       "NoDistortion", init<>());
+  register_ptr_to_python<boost::shared_ptr<NoDistortion> >();
+
   exportGenericDistortionFunctions<NoDistortion>(noDistortion);
 
   class_<EquidistantDistortion, boost::shared_ptr<EquidistantDistortion> > equidistantDistortion(
       "EquidistantDistortion", init<>());
+  register_ptr_to_python<boost::shared_ptr<EquidistantDistortion> >();
+
   equidistantDistortion.def(init<double, double, double, double>());
   exportGenericDistortionFunctions<EquidistantDistortion>(
       equidistantDistortion);

--- a/aslam_cv/aslam_cv_python/src/CameraShutters.cpp
+++ b/aslam_cv/aslam_cv_python/src/CameraShutters.cpp
@@ -40,6 +40,8 @@ void exportGlobalShutter(std::string name) {
       name.c_str(), init<>());
   globalShutter.def(init<>((name + "()").c_str()));
 
+  register_ptr_to_python<boost::shared_ptr<GlobalShutter> >();
+
   exportGenericShutterFunctions<GlobalShutter>(globalShutter);
 }
 
@@ -51,6 +53,8 @@ void exportRollingShutter(std::string name) {
       init<double>((name + "(double lineDelay)").c_str())).def(
       "lineDelay", &RollingShutter::lineDelay,
       "Returns the Line Delay of the Rolling Shutter");
+
+  register_ptr_to_python<boost::shared_ptr<RollingShutter> >();
 
   exportGenericShutterFunctions<RollingShutter>(rollingShutter);
 }

--- a/aslam_optimizer/aslam_backend_python/include/aslam/python/ExportDesignVariableAdapter.hpp
+++ b/aslam_optimizer/aslam_backend_python/include/aslam/python/ExportDesignVariableAdapter.hpp
@@ -26,6 +26,7 @@ namespace aslam {
   class_< DesignVariableAdapter<dv_t>, boost::shared_ptr<DesignVariableAdapter<dv_t> >, bases<DesignVariable> >( name.c_str(), init<boost::shared_ptr< dv_t> >() )
 	.def("value", &DesignVariableAdapter<dv_t>::valuePtr)
   ;
+  register_ptr_to_python<boost::shared_ptr<DesignVariableAdapter<dv_t> > >();
   //boost::python::implicitly_convertible<boost::shared_ptr<DesignVariableAdapter<dv_t> >, boost::shared_ptr<DesignVariable> >();
   
   }


### PR DESCRIPTION
_ reflects changes in boost_serialization as of 1.59
_ explicitly calls ptr_to_python converters which is currently required for boost 1.60 (see: boostorg/python/issues/56)
